### PR TITLE
Cache only top level llm query

### DIFF
--- a/abstract_ranker/llm_utils.py
+++ b/abstract_ranker/llm_utils.py
@@ -1,8 +1,13 @@
 from typing import Any, Callable, Dict, List
 
+from joblib import Memory
+
+from abstract_ranker.config import CACHE_DIR
 from abstract_ranker.data_model import AbstractLLMResponse
 from abstract_ranker.local_llms import query_hugging_face
 from abstract_ranker.openai_utils import query_gpt
+
+memory_llm_query = Memory(CACHE_DIR / "llm_queries", verbose=0)
 
 
 _llm_dispatch: Dict[str, Callable[[str, Dict[Any, Any]], AbstractLLMResponse]] = {
@@ -24,6 +29,7 @@ def get_llm_models() -> List[str]:
     return list(_llm_dispatch.keys())
 
 
+@memory_llm_query.cache
 def query_llm(prompt: str, context: Dict[str, str], model: str) -> AbstractLLMResponse:
     """Query the given LLM for a summary.
 

--- a/abstract_ranker/local_llms.py
+++ b/abstract_ranker/local_llms.py
@@ -1,17 +1,12 @@
 import logging
 from typing import Any, Dict
 
-from joblib import Memory
 from lmformatenforcer import JsonSchemaParser
 from lmformatenforcer.integrations.transformers import (
     build_transformers_prefix_allowed_tokens_fn,
 )
 
-from abstract_ranker.config import CACHE_DIR
 from abstract_ranker.data_model import AbstractLLMResponse
-
-memory_hf = Memory(CACHE_DIR / "huggingface_llms", verbose=0)
-
 
 _hf_models: Dict[str, Any] = {}
 
@@ -49,7 +44,6 @@ def create_pipeline(model_name: str):
     return _hf_models[model_name]
 
 
-@memory_hf.cache
 def query_hugging_face(
     query: str, context: Dict[str, str], model_name: str
 ) -> AbstractLLMResponse:

--- a/abstract_ranker/openai_utils.py
+++ b/abstract_ranker/openai_utils.py
@@ -3,19 +3,14 @@ from pathlib import Path
 from typing import Dict
 
 import openai
-from joblib import Memory
 
-from abstract_ranker.config import CACHE_DIR
 from abstract_ranker.data_model import AbstractLLMResponse
-
-memory_openapi = Memory(CACHE_DIR / "openapi", verbose=0)
 
 
 def get_key():
     return Path(".openai_key").read_text().strip()
 
 
-@memory_openapi.cache
 def query_gpt(prompt: str, context: Dict[str, str], model: str) -> AbstractLLMResponse:
     """Queries LLM `model` with a prompt and context.
 


### PR DESCRIPTION
* Remove caching from most individual queries
* The overal query dispatcher is now cached.


Fixes #8