### PR TITLE
Split the topics into several bits

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,6 +2,7 @@
   "cSpell.words": [
     "autouse",
     "Calo",
+    "dtype",
     "filelock",
     "generalisation",
     "generalise",

--- a/abstract_ranker/config.py
+++ b/abstract_ranker/config.py
@@ -5,22 +5,23 @@ CACHE_DIR = Path("./.abstract_cache")
 
 # Raw prompt for the LLM
 abstract_ranking_prompt = """Help me judge the following conference presentation as interesting or
-not. My interests are in the following areas:
-
-    1. Hidden Sector Physics
-    2. Long Lived Particles (Exotics or RPV SUSY)
-    3. Analysis techniques and methods and frameworks, particularly those based around python or
-       ROOT's DataFrame (RDF)
-    4. Machine Learning and AI for particle physics
-    5. The ServiceX tool
-    6. Distributed computing for analysis (e.g. Dask, Spark, etc)
-    7. Data Preservation and FAIR principles
-    8. Differentiable Programming
-
-I am *not interested* in:
-
-    1. Quantum Computing
-    2. Lattice Gauge Theory
-    3. Neutrino Physics
-
+not by summarizing the abstract and ranking it according to topics I'm interested in or not.
 """
+
+interested_topics = [
+    "Hidden Sector Physics",
+    "Long Lived Particles (Exotics or RPV SUSY)",
+    "Analysis techniques and methods and frameworks, particularly those based around python or "
+    "ROOT's DataFrame (RDF)",
+    "Machine Learning and AI for particle physics",
+    "The ServiceX tool",
+    "Distributed computing for analysis (e.g. Dask, Spark, etc)",
+    "Data Preservation and FAIR principles",
+    "Differentiable Programming",
+]
+
+not_interested_topics = [
+    "Quantum Computing",
+    "Lattice Gauge Theory",
+    "Neutrino Physics",
+]

--- a/abstract_ranker/data_model.py
+++ b/abstract_ranker/data_model.py
@@ -6,7 +6,11 @@ class AbstractLLMResponse(BaseModel):
     "Result back from LLM grading of an abstract"
 
     # Summary of the abstract
-    summary: str = Field(..., title="The one-line summary of the abstract")
+    summary: str = Field(
+        ...,
+        title="A short summary of the abstract that does not repeat the title, no more than 200 "
+        "characters.",
+    )
 
     # The most likely experiment this is associated with
     experiment: str = Field(
@@ -17,18 +21,19 @@ class AbstractLLMResponse(BaseModel):
 
     # List of keywords
     keywords: List[str] = Field(
-        ..., title="List of keywords associated with the abstract"
+        ..., title="Short list of keywords associated with the abstract"
     )
 
     # What is the interest level here?
     interest: str = Field(
-        ..., title="Interest level in the abstract (high, medium, or low)"
+        ..., title="'high', 'medium', or 'low': how interesting I'll find the abstract."
     )
 
     # A short explanation of why the interest level is what it is
     explanation: str = Field(
         ...,
-        title="Explanation of the interest level in the abstract. Very short!",
+        title="Very short explanation of the interest level in the abstract. No more than a "
+        "single sentence, 100 words maximum.",
     )
 
 

--- a/abstract_ranker/llm_utils.py
+++ b/abstract_ranker/llm_utils.py
@@ -30,7 +30,9 @@ def get_llm_models() -> List[str]:
 
 
 @memory_llm_query.cache
-def query_llm(prompt: str, context: Dict[str, str], model: str) -> AbstractLLMResponse:
+def query_llm(
+    prompt: str, context: Dict[str, str | List[str]], model: str
+) -> AbstractLLMResponse:
     """Query the given LLM for a summary.
 
     Args:

--- a/abstract_ranker/local_llms.py
+++ b/abstract_ranker/local_llms.py
@@ -89,7 +89,7 @@ def query_hugging_face(
         },
         {
             "role": "user",
-            "content": "Please answer in the JSON scheme: "
+            "content": "Phrase your answer as carefully considered JSON in the following schema:\n"
             f"{AbstractLLMResponse.model_json_schema()}",
         },
     ]

--- a/abstract_ranker/ranker.py
+++ b/abstract_ranker/ranker.py
@@ -6,7 +6,11 @@ from typing import Any, Dict, Generator, Optional
 from pydantic import BaseModel
 from rich.progress import Progress
 
-from abstract_ranker.config import abstract_ranking_prompt
+from abstract_ranker.config import (
+    abstract_ranking_prompt,
+    interested_topics,
+    not_interested_topics,
+)
 from abstract_ranker.indico import IndicoDate, load_indico_json
 from abstract_ranker.llm_utils import get_llm_models, query_llm
 from abstract_ranker.utils import generate_ranking_csv_filename
@@ -103,7 +107,12 @@ def process_contributions(
                 if not (contrib.description is None or len(contrib.description) < 10):
                     summary = query_llm(
                         prompt,
-                        {"title": contrib.title, "abstract": contrib.description},
+                        {
+                            "title": contrib.title,
+                            "abstract": contrib.description,
+                            "interesting_topics": interested_topics,
+                            "not_interesting_topics": not_interested_topics,
+                        },
                         model,
                     )
 

--- a/abstract_ranker/ranker.py
+++ b/abstract_ranker/ranker.py
@@ -110,8 +110,8 @@ def process_contributions(
                         {
                             "title": contrib.title,
                             "abstract": contrib.description,
-                            "interesting_topics": interested_topics,
-                            "not_interesting_topics": not_interested_topics,
+                            "interested_topics": interested_topics,
+                            "not_interested_topics": not_interested_topics,
                         },
                         model,
                     )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,7 @@ dependencies = [
   'accelerate',
   'lm-format-enforcer',
   'rich',
+  'tenacity',
   # 'flash-attn', Needed only for training?
 ]
 # You will need pytorch too for running against phi3

--- a/tests/test_local_llms.py
+++ b/tests/test_local_llms.py
@@ -3,7 +3,11 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from abstract_ranker.config import abstract_ranking_prompt
+from abstract_ranker.config import (
+    abstract_ranking_prompt,
+    interested_topics,
+    not_interested_topics,
+)
 from abstract_ranker.local_llms import query_hugging_face
 
 
@@ -26,7 +30,7 @@ def pipeline_callback():
                 ) -> List[Dict[str, str]]:
                     nonlocal call_message
                     assert isinstance(msg, list)
-                    assert len(msg) == 2
+                    assert len(msg) == 7
                     call_message = msg
                     return [
                         {
@@ -50,7 +54,12 @@ def test_hf(pipeline_callback, setup_before_test):
 
     result = query_hugging_face(
         "What is the summary?",
-        {"title": "Title", "abstract": "Abstract"},
+        {
+            "title": "Title",
+            "abstract": "Abstract",
+            "interested_topics": ["one", "two"],
+            "not_interested_topics": ["three", "four"],
+        },
         "microsoft/Phi-3-mini-4k-instruct",
     )
     # Check the result
@@ -86,7 +95,12 @@ model for calorimeter shower generation."""
 
     r = query_hugging_face(
         abstract_ranking_prompt,
-        {"title": title, "abstract": abstract},
+        {
+            "title": title,
+            "abstract": abstract,
+            "interested_topics": interested_topics,
+            "not_interested_topics": not_interested_topics,
+        },
         "microsoft/Phi-3-mini-4k-instruct",
     )
 


### PR DESCRIPTION
* Split good/bad topics into individual lists that are grabbed from the `config`
* Increase the max # of tokens from a local model to 1024
* Better tune the comments in the `data_model` to get better performance.
* Automatically retry the request if the JSON returned is not valid.

Fixes #14