### PR TITLE
Run local models, like phi3, on WSL and UChicago

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -122,6 +122,7 @@ celerybeat.pid
 # Environments
 .env
 .venv
+.conda/
 env/
 venv/
 ENV/

--- a/README.md
+++ b/README.md
@@ -10,12 +10,16 @@ It worked surprisingly well. Enough to make me wonder if I shouldn't be using so
 
 ## Other info
 
-Using gpt 3.5 turbo cost pannies to do this, and 4 turbo cost about $1.60 US. I didn't get as far as comparing the results of the two to know if the 3.5 was good enough.
+Using gpt 3.5 turbo cost pennies to do this, and 4 turbo cost about $1.60 US. I didn't get as far as comparing the results of the two to know if the 3.5 was good enough.
 
 ## Tyring it out
 
 The following is a way to use `phi-3` mini as an example:
 
 ```bash
- python .\abstract_ranker\ranker.py rank https://indico.cern.ch/event/1330797/contributions --model phi3-mini -v
+ abstract_ranker rank https://indico.cern.ch/event/1330797/contributions --model phi3-mini -v
 ```
+
+Notes:
+
+* On UChicago use a 2080. The A100 MIG's do not have enough memory even for a mini.

--- a/README.md
+++ b/README.md
@@ -26,7 +26,10 @@ I had a lot of trouble here - so keeping a log:
 
 1. Use `nvcc --version` to determine what `cuda` version you have on your local machine.
 1. Use [these instructions](https://pytorch.org/get-started/locally/) to install pytorch. I did it in a conda environment, but a `venv` that uses `pip` should be fine too.
-1. Use the usual `pip install -e .[test]`
+1. Use the usual `pip install -e .[test,ml]`
+    * Note that this needs to be run on a Linux with a decent size GPU.
+    * phi3-mini will work on a smaller GPU (like a 2080 TI).
+    * phi3-small requires something larger.
 
 Notes:
 

--- a/README.md
+++ b/README.md
@@ -20,6 +20,14 @@ The following is a way to use `phi-3` mini as an example:
  abstract_ranker rank https://indico.cern.ch/event/1330797/contributions --model phi3-mini -v
 ```
 
+### Installing pytorch with cuda
+
+I had a lot of trouble here - so keeping a log:
+
+1. Use `nvcc --version` to determine what `cuda` version you have on your local machine.
+1. Use [these instructions](https://pytorch.org/get-started/locally/) to install pytorch. I did it in a conda environment, but a `venv` that uses `pip` should be fine too.
+1. Use the usual `pip install -e .[test]`
+
 Notes:
 
 * On UChicago use a 2080. The A100 MIG's do not have enough memory even for a mini.

--- a/abstract_ranker/llm_utils.py
+++ b/abstract_ranker/llm_utils.py
@@ -1,4 +1,4 @@
-from typing import Any, Callable, Dict, List
+from typing import Any, Callable, Dict, List, Union
 
 from joblib import Memory
 
@@ -31,7 +31,7 @@ def get_llm_models() -> List[str]:
 
 @memory_llm_query.cache
 def query_llm(
-    prompt: str, context: Dict[str, str | List[str]], model: str
+    prompt: str, context: Dict[str, Union[str, List[str]]], model: str
 ) -> AbstractLLMResponse:
     """Query the given LLM for a summary.
 

--- a/abstract_ranker/llm_utils.py
+++ b/abstract_ranker/llm_utils.py
@@ -17,6 +17,9 @@ _llm_dispatch: Dict[str, Callable[[str, Dict[Any, Any]], AbstractLLMResponse]] =
     "phi3-mini": lambda prompt, context: query_hugging_face(
         prompt, context, "microsoft/Phi-3-mini-4k-instruct"
     ),
+    "phi3-small": lambda prompt, context: query_hugging_face(
+        prompt, context, "microsoft/Phi-3-small-8k-instruct"
+    ),
 }
 
 

--- a/abstract_ranker/local_llms.py
+++ b/abstract_ranker/local_llms.py
@@ -1,5 +1,5 @@
 import logging
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Union
 
 from lmformatenforcer import JsonSchemaParser
 from lmformatenforcer.integrations.transformers import (
@@ -48,7 +48,7 @@ def create_pipeline(model_name: str):
 
 @retry(stop=stop_after_attempt(3), retry=retry_if_exception_type(ValidationError))
 def query_hugging_face(
-    query: str, context: Dict[str, str | List[str]], model_name: str
+    query: str, context: Dict[str, Union[str, List[str]]], model_name: str
 ) -> AbstractLLMResponse:
     """Use the `transformers` library to run a query from huggingface.co.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,11 +14,7 @@ dependencies = [
   'transformers[torch]',
   'tenacity',
   'openai',
-#  'pyyaml',
-#  'accelerate',
-#  'tiktoken==0.6.0',
-#  'triton=2.3.0',
-  # 'flash-attn', Needed only for training?
+# Required for phi3-small
 ]
 # You will need pytorch too for running against phi3
 # pip3 install torch torchvision torchaudio --index-url https://download.pytorch.org/whl/cu121
@@ -52,6 +48,8 @@ packages = ["abstract_ranker"]
 
 [project.optional-dependencies]
 test = ["pytest", "black", "flake8"]
+# Use 'ml' this for running things like phi3-small (need linux!).
+ml = ['einops', 'flash-attn', 'tiktoken==0.6.0']
 
 [project.scripts]
 abstract_ranker = "abstract_ranker.ranker:main"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,14 +8,16 @@ dependencies = [
   'joblib',
   'pydantic',
   'requests',
-  'tzlocal',
-  'openai',
-  'pyyaml',
-  'transformers',
-  'accelerate',
-  'lm-format-enforcer',
   'rich',
+  'tzlocal',
+  'lm-format-enforcer',
+  'transformers[torch]',
   'tenacity',
+  'openai',
+#  'pyyaml',
+#  'accelerate',
+#  'tiktoken==0.6.0',
+#  'triton=2.3.0',
   # 'flash-attn', Needed only for training?
 ]
 # You will need pytorch too for running against phi3


### PR DESCRIPTION
* Got this running on WSL without changes
* Running on UChicago's AF meant using a 2080, and also working with python 3.8 (`Union` for types had to be used).
* Later updates to UChicago seem to make this better.
* While `phi3-mini` will run on a 2080, it won't run `phi3-small` (see #29). However, `phi3-small` is ready to go (probably).
* Updated `README` to document some of these changes
* Added enough infrastructure so `conda` environments don't cause surprises.

Fixes #25