### PR TITLE
Make sure to trust remote code (phi3-small requires this).

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ I had a lot of trouble here - so keeping a log:
 1. Use the usual `pip install -e .[test,ml]`
     * Note that this needs to be run on a Linux with a decent size GPU.
     * phi3-mini will work on a smaller GPU (like a 2080 TI).
+    * phi3-small needs a modern GPU to run (like an A100 - not a V100!).
     * phi3-small requires something larger.
 
 Notes:

--- a/abstract_ranker/local_llms.py
+++ b/abstract_ranker/local_llms.py
@@ -37,10 +37,10 @@ def create_pipeline(model_name: str):
             torch_dtype="auto",
             trust_remote_code=True,
         )
-        tokenizer = AutoTokenizer.from_pretrained(model_name)
+        tokenizer = AutoTokenizer.from_pretrained(model_name, trust_remote_code=True)
 
         _hf_models[model_name] = pipeline(
-            "text-generation", model=model, tokenizer=tokenizer
+            "text-generation", model=model, tokenizer=tokenizer, trust_remote_code=True
         )
 
     return _hf_models[model_name]


### PR DESCRIPTION
* Trust remote code (required by phi3-small).
* Add note to README about where phi3 can run

Working towards #29
