### PR TITLE
OpenAI Updates

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,6 @@
 {
   "cSpell.words": [
+    "addinivalue",
     "autouse",
     "Calo",
     "dtype",
@@ -16,6 +17,7 @@
     "lmformatenforcer",
     "localzone",
     "MATHUSLA",
+    "modifyitems",
     "openai",
     "pydantic",
     "pytz",

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -20,6 +20,7 @@
     "modifyitems",
     "openai",
     "pydantic",
+    "pytestmark",
     "pytz",
     "SUSY",
     "tzlocal",

--- a/abstract_ranker/data_model.py
+++ b/abstract_ranker/data_model.py
@@ -21,7 +21,7 @@ class AbstractLLMResponse(BaseModel):
 
     # List of keywords
     keywords: List[str] = Field(
-        ..., title="Short list of keywords associated with the abstract"
+        ..., title="Short JSON list of string-keywords associated with the abstract"
     )
 
     # What is the interest level here?

--- a/abstract_ranker/llm_utils.py
+++ b/abstract_ranker/llm_utils.py
@@ -4,20 +4,41 @@ from joblib import Memory
 
 from abstract_ranker.config import CACHE_DIR
 from abstract_ranker.data_model import AbstractLLMResponse
-from abstract_ranker.local_llms import query_hugging_face
-from abstract_ranker.openai_utils import query_gpt
 
 memory_llm_query = Memory(CACHE_DIR / "llm_queries", verbose=0)
 
 
+def local_query_gpt(
+    prompt: str, context: Dict[str, Union[str, List[str]]], model: str
+) -> AbstractLLMResponse:
+    from abstract_ranker.openai_utils import query_gpt
+
+    return query_gpt(prompt, context, model)
+
+
+def local_query_hugging_face(
+    query: str, context: Dict[str, Union[str, List[str]]], model_name: str
+) -> AbstractLLMResponse:
+    from abstract_ranker.local_llms import query_hugging_face
+
+    return query_hugging_face(query, context, model_name)
+
+
 _llm_dispatch: Dict[str, Callable[[str, Dict[Any, Any]], AbstractLLMResponse]] = {
-    "GPT4Turbo": lambda prompt, context: query_gpt(prompt, context, "gpt-4-turbo"),
-    "GPT4o": lambda prompt, context: query_gpt(prompt, context, "gpt-4o"),
-    "GPT35Turbo": lambda prompt, context: query_gpt(prompt, context, "gpt-3.5-turbo"),
-    "phi3-mini": lambda prompt, context: query_hugging_face(
+    "GPT4Turbo": lambda prompt, context: local_query_gpt(
+        prompt, context, "gpt-4-turbo"
+    ),
+    "GPT4o": lambda prompt, context: local_query_gpt(prompt, context, "gpt-4o"),
+    "GPT4o-mini": lambda prompt, context: local_query_gpt(
+        prompt, context, "gpt-4o-mini"
+    ),
+    "GPT35Turbo": lambda prompt, context: local_query_gpt(
+        prompt, context, "gpt-3.5-turbo"
+    ),
+    "phi3-mini": lambda prompt, context: local_query_hugging_face(
         prompt, context, "microsoft/Phi-3-mini-4k-instruct"
     ),
-    "phi3-small": lambda prompt, context: query_hugging_face(
+    "phi3-small": lambda prompt, context: local_query_hugging_face(
         prompt, context, "microsoft/Phi-3-small-8k-instruct"
     ),
 }

--- a/abstract_ranker/openai_utils.py
+++ b/abstract_ranker/openai_utils.py
@@ -24,7 +24,11 @@ def query_gpt(
     Returns:
         AbstractLLMResponse: The parsed json response from open AI.
     """
-    # Generate the completion using OpenAI GPT-3.5 Turbo
+    # Fix up Schema to make it easier for the LLM to interpret.
+    schema = AbstractLLMResponse.model_json_schema()["properties"]
+    schema = {k: v["title"] for k, v in schema.items()}
+
+    # Generate the completion using OpenAI
     openai_client = openai.OpenAI(api_key=get_key())
     response = openai_client.chat.completions.create(
         model=model,
@@ -55,10 +59,10 @@ def query_gpt(
             },
             {
                 "role": "user",
-                "content": "Your answer should be correct JSON using in the following schema. And "
-                "everything should be short and succinct with no emoji. Here is the answer schema"
-                "as a template:\n"
-                f"{AbstractLLMResponse.model_json_schema()['properties']}",
+                "content": "Your answer should be correct JSON using in the following JSON schema. "
+                "Everything should be short and succinct with no emoji: This is a JSON schema, so "
+                "replace the title and type dict with the actual data: \n"
+                f"{schema}",
             },
         ],
         max_tokens=1000,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,10 +11,8 @@ dependencies = [
   'rich',
   'tzlocal',
   'lm-format-enforcer',
-  'transformers[torch]',
   'tenacity',
   'openai',
-# Required for phi3-small
 ]
 # You will need pytorch too for running against phi3
 # pip3 install torch torchvision torchaudio --index-url https://download.pytorch.org/whl/cu121
@@ -49,7 +47,7 @@ packages = ["abstract_ranker"]
 [project.optional-dependencies]
 test = ["pytest", "black", "flake8"]
 # Use 'ml' this for running things like phi3-small (need linux!).
-ml = ['einops', 'flash-attn', 'tiktoken==0.6.0']
+ml = ['einops', 'flash-attn', 'tiktoken==0.6.0', 'transformers[torch]']
 
 [project.scripts]
 abstract_ranker = "abstract_ranker.ranker:main"

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+markers =
+    requires_torch: mark a test as requiring torch

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,6 +2,38 @@ from unittest.mock import patch
 import pytest
 
 
+def pytest_configure(config):
+    """Add custom markers to pytest.
+
+    Args:
+        config (_type_): _description_
+    """
+    config.addinivalue_line(
+        "markers",
+        "requires_pytorch: mark test to be skipped if pytorch is not installed",
+    )
+
+
+def is_torch_installed():
+    import importlib.util
+
+    return importlib.util.find_spec("torch") is not None
+
+
+def pytest_collection_modifyitems(config, items):
+    """Skip tests that require pytorch if it is not installed.
+
+    Args:
+        config (_type_): _description_
+        items (_type_): _description_
+    """
+    if not is_torch_installed():
+        skip_pytorch = pytest.mark.skip(reason="pytorch is not installed")
+        for item in items:
+            if "requires_pytorch" in item.keywords:
+                item.add_marker(skip_pytorch)
+
+
 @pytest.fixture(autouse=True)
 def cache_dir(tmp_path):
     # Create a temporary test directory
@@ -14,7 +46,8 @@ def cache_dir(tmp_path):
 
 @pytest.fixture(autouse=True)
 def setup_before_test():
-    "Reset state"
-    from abstract_ranker.local_llms import reset
+    if is_torch_installed():
+        "Reset state"
+        from abstract_ranker.local_llms import reset
 
-    reset()
+        reset()

--- a/tests/test_llm_utils.py
+++ b/tests/test_llm_utils.py
@@ -31,7 +31,7 @@ def test_cache(cache_dir):
     "Make sure that caching is used if called twice"
 
     # with patch("abstract_ranker.openai_utils.query_gpt") as mock_query_gpt:
-    with patch("abstract_ranker.llm_utils.query_gpt") as mock_query_gpt:
+    with patch("abstract_ranker.llm_utils.local_query_gpt") as mock_query_gpt:
         from abstract_ranker.llm_utils import AbstractLLMResponse
 
         mock_query_gpt.return_value = AbstractLLMResponse(

--- a/tests/test_local_llms.py
+++ b/tests/test_local_llms.py
@@ -3,12 +3,18 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from abstract_ranker.config import (
-    abstract_ranking_prompt,
-    interested_topics,
-    not_interested_topics,
-)
-from abstract_ranker.local_llms import query_hugging_face
+pytestmark = pytest.mark.requires_pytorch
+
+try:
+    from abstract_ranker.config import (
+        abstract_ranking_prompt,
+        interested_topics,
+        not_interested_topics,
+    )
+    from abstract_ranker.local_llms import query_hugging_face
+except ImportError:
+    # These fail if the `pytestmark` is not true.
+    pass
 
 
 @pytest.fixture

--- a/tests/test_openai_utils.py
+++ b/tests/test_openai_utils.py
@@ -2,6 +2,9 @@ from dataclasses import dataclass
 from typing import List
 from unittest.mock import patch
 
+from pydantic import ValidationError
+import pytest
+
 
 @dataclass
 class message:
@@ -60,3 +63,73 @@ def test_openai_simple_call():
                 mock_openai.return_value.chat.completions.create.call_args[1]["model"]
                 == "gpt-4-turbo-bogus"
             )
+
+
+def test_openai_json_header_trailer_removal():
+    with patch("openai.OpenAI") as mock_openai:
+        with patch("abstract_ranker.openai_utils.get_key") as mock_get_key:
+            mock_get_key.return_value = "bogus_key"
+
+            mock_openai.return_value.chat.completions.create.return_value = response(
+                choices=[
+                    choice(
+                        message=message(
+                            content='json\n{"summary": "hi", "experiment": "", "keywords": [], '
+                            '"interest": "", "explanation": ""}```'
+                        )
+                    )
+                ]
+            )
+
+            from abstract_ranker.openai_utils import query_gpt
+            from abstract_ranker.llm_utils import AbstractLLMResponse
+
+            r = query_gpt(
+                "hi",
+                {
+                    "title": "hi",
+                    "abstract": "hi",
+                    "interested_topics": ["hi", "there"],
+                    "not_interested_topics": ["no", "thanks"],
+                },
+                "gpt-4-turbo-bogus",
+            )
+            assert isinstance(r, AbstractLLMResponse)
+            assert r.summary == "hi"
+            assert r.experiment == ""
+            assert r.keywords == []
+            assert r.interest == ""
+            assert r.explanation == ""
+
+            mock_openai.assert_called_once()
+            mock_openai.return_value.chat.completions.create.assert_called_once()
+            assert (
+                mock_openai.return_value.chat.completions.create.call_args[1]["model"]
+                == "gpt-4-turbo-bogus"
+            )
+
+
+def test_openai_bad_response():
+    with patch("openai.OpenAI") as mock_openai:
+        with patch("abstract_ranker.openai_utils.get_key") as mock_get_key:
+            mock_get_key.return_value = "bogus_key"
+
+            mock_openai.return_value.chat.completions.create.return_value = response(
+                choices=[choice(message=message(content="fork it"))]
+            )
+
+            from abstract_ranker.openai_utils import query_gpt
+
+            with pytest.raises(ValidationError) as e:
+                query_gpt(
+                    "hi",
+                    {
+                        "title": "hi",
+                        "abstract": "hi",
+                        "interested_topics": ["hi", "there"],
+                        "not_interested_topics": ["no", "thanks"],
+                    },
+                    "gpt-4-turbo-bogus",
+                )
+
+            assert "validation error" in str(e.value)

--- a/tests/test_openai_utils.py
+++ b/tests/test_openai_utils.py
@@ -37,7 +37,16 @@ def test_openai_simple_call():
             from abstract_ranker.openai_utils import query_gpt
             from abstract_ranker.llm_utils import AbstractLLMResponse
 
-            r = query_gpt("hi", {"title": "hi", "abstract": "hi"}, "gpt-4-turbo-bogus")
+            r = query_gpt(
+                "hi",
+                {
+                    "title": "hi",
+                    "abstract": "hi",
+                    "interested_topics": ["hi", "there"],
+                    "not_interested_topics": ["no", "thanks"],
+                },
+                "gpt-4-turbo-bogus",
+            )
             assert isinstance(r, AbstractLLMResponse)
             assert r.summary == "hi"
             assert r.experiment == ""


### PR DESCRIPTION
All the changes to run local models mean the OpenAI code is no longer running. This PR fixes that.

* Add the 4o-mini model (it cost 2 cents to run ACAT 2024)
* Updated to run on the current 4o model (cost 70 cents to run ACAT 2024)
* Minor adjustments to the data model descriptions to improve the response
* Simplify the schema that is sent to the openai models
* Trim headers and footers
* Add directives to avoid latex escape sequences

## Other Improvements

* Refactoring so can run even if pytorch isn't installed.
* Refactor tests so they run even if `torch` isn't installed (ops, should have been done before!).

Fixes #13