### PR TITLE
Enable looking at talks that have no abstract

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.8, 3.9, "3.10", 3.11, 3.12]
+        python-version: ["3.10", 3.11, 3.12]
 
     steps:
       - uses: actions/checkout@v4

--- a/abstract_ranker/data_model.py
+++ b/abstract_ranker/data_model.py
@@ -9,7 +9,7 @@ class AbstractLLMResponse(BaseModel):
     summary: str = Field(
         ...,
         title="A short summary of the abstract that does not repeat the title, no more than 200 "
-        "characters.",
+        "characters. If there is no abstract provided, just repeat the title.",
     )
 
     # The most likely experiment this is associated with
@@ -26,7 +26,9 @@ class AbstractLLMResponse(BaseModel):
 
     # What is the interest level here?
     interest: str = Field(
-        ..., title="'high', 'medium', or 'low': how interesting I'll find the abstract."
+        ...,
+        title="The string 'high', 'medium', or 'low' indicating how interesting I'll find "
+        "the abstract.",
     )
 
     # A short explanation of why the interest level is what it is
@@ -49,14 +51,3 @@ class AbstractLLMResponse(BaseModel):
         title="Short JSON list of terms (strings) in the abstract whose definition would "
         "improve your confidence.",
     )
-
-
-# Please format your with a summary  (One line, terse, summary of the abstract that
-# does not repeat the title. It should add extra information beyond the title, and should mention
-# any key outcomes that are present in the abstract), an experiment name (If you can guess the
-# experiment this abstract is associated with (e.g. ATLAS, CMS, LHCb, etc), place it here.
-# Otherwise
-# leave it blank), a list of keywords (json-list of 4 or less keywords or phrases describing topics
-# in the below abstract and title, comma separated, pulled from my list of interests), and my
-# expected interest(put: "high" (hits several of the interests listed above), "medium" (hits one
-# interest), or "low" (hits a not interest). Be harsh, my time is valuable).

--- a/abstract_ranker/ranker.py
+++ b/abstract_ranker/ranker.py
@@ -106,43 +106,49 @@ def process_contributions(
                 else None
             )
             for contrib in contributions(data):
-                if not (contrib.description is None or len(contrib.description) < 10):
-                    summary = query_llm(
-                        prompt,
-                        {
-                            "title": contrib.title,
-                            "abstract": contrib.description,
-                            "interested_topics": interested_topics,
-                            "not_interested_topics": not_interested_topics,
-                        },
-                        model,
-                        use_cache,
+                abstract_text = (
+                    contrib.description
+                    if not (
+                        contrib.description is None or len(contrib.description) < 10
                     )
+                    else "Not given"
+                )
+                summary = query_llm(
+                    prompt,
+                    {
+                        "title": contrib.title,
+                        "abstract": abstract_text,
+                        "interested_topics": interested_topics,
+                        "not_interested_topics": not_interested_topics,
+                    },
+                    model,
+                    use_cache,
+                )
 
-                    # Write the row to the CSV file
-                    writer.writerow(
-                        [
-                            (
-                                contrib.startDate.get_local_datetime()[0]
-                                if contrib.startDate
-                                else ""
-                            ),
-                            (
-                                contrib.startDate.get_local_datetime()[1]
-                                if contrib.startDate
-                                else ""
-                            ),
-                            contrib.roomFullname if contrib.roomFullname else "",
-                            contrib.title,
-                            summary.summary,
-                            summary.experiment,
-                            summary.keywords,
-                            as_a_number(summary.interest),
-                            contrib.type,
-                            summary.confidence,
-                            summary.unknown_terms,
-                        ]
-                    )
+                # Write the row to the CSV file
+                writer.writerow(
+                    [
+                        (
+                            contrib.startDate.get_local_datetime()[0]
+                            if contrib.startDate
+                            else ""
+                        ),
+                        (
+                            contrib.startDate.get_local_datetime()[1]
+                            if contrib.startDate
+                            else ""
+                        ),
+                        contrib.roomFullname if contrib.roomFullname else "",
+                        contrib.title,
+                        summary.summary,
+                        summary.experiment,
+                        summary.keywords,
+                        as_a_number(summary.interest),
+                        contrib.type,
+                        summary.confidence,
+                        summary.unknown_terms,
+                    ]
+                )
                 if task is not None:
                     progress.update(task, advance=1)
 

--- a/abstract_ranker/ranker.py
+++ b/abstract_ranker/ranker.py
@@ -176,7 +176,13 @@ def main():
 
     subparsers = parser.add_subparsers(dest="command", help="sub-command help")
 
-    rank_parser = subparsers.add_parser("rank", help="Rank contributions")
+    rank_parser = subparsers.add_parser(
+        "rank",
+        help="Rank contributions",
+        description="""
+    Rank the contributions of an Indico event and write them to a CSV file by interest from low (1) to high (3)
+    Includes a summary of the contribution's abstract if there was an abstract provided.""",
+    )
     rank_parser.add_argument("indico_url", type=str, help="URL of the indico event")
     rank_parser.add_argument(
         "--model",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,15 +21,13 @@ name = "conference-llm-tools"
 dynamic = ["version"]
 description = 'Tools to work with conferences in indico with LLMs as an assistant'
 readme = "README.md"
-requires-python = ">=3.8"
+requires-python = ">=3.10"
 license = "MIT"
 keywords = []
 authors = [{ name = "Gordon Watts", email = "gwatts@uw.edu" }]
 classifiers = [
   "Development Status :: 4 - Beta",
   "Programming Language :: Python",
-  "Programming Language :: Python :: 3.8",
-  "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",

--- a/tests/test_openai_utils.py
+++ b/tests/test_openai_utils.py
@@ -135,3 +135,48 @@ def test_openai_bad_response():
                 )
 
             assert "validation error" in str(e.value)
+
+
+def test_openai_latex_response():
+    with patch("openai.OpenAI") as mock_openai:
+        with patch("abstract_ranker.openai_utils.get_key") as mock_get_key:
+            mock_get_key.return_value = "bogus_key"
+
+            mock_openai.return_value.chat.completions.create.return_value = response(
+                choices=[
+                    choice(
+                        message=message(
+                            content="""{
+    "summary": "Not given",
+    "experiment": "",
+    "keywords": ["b to s transitions", "flavor physics", "lepton interactions"],
+    "interest": "low",
+    "explanation": "The topic of $b \\to s \\ell \\ell$ fits does not align with my interests \
+in hidden sector physics or long-lived particles.",
+    "confidence": 0.3,
+    "unknown_terms": []
+}
+"""
+                        )
+                    )
+                ]
+            )
+
+            from abstract_ranker.openai_utils import query_gpt
+
+            r = query_gpt(
+                "hi",
+                {
+                    "title": "hi",
+                    "abstract": "hi",
+                    "interested_topics": ["hi", "there"],
+                    "not_interested_topics": ["no", "thanks"],
+                },
+                "gpt-4-turbo-bogus",
+            )
+
+            assert (
+                r.explanation
+                == "The topic of $b \\to s \\ell \\ell$ fits does not align with my interests "
+                "in hidden sector physics or long-lived particles."
+            )


### PR DESCRIPTION
* Allow an empty abstract in (they were skipped previously).
* Make sure we use `low`, '`medium` or `high` rather than 1, 2, or 3.
* Pass the title through as the summary when there is no abstract

## Minor

* Improve the `rank` command hepl file
* Only support python `3.10` or better

Fixes #38