### PR TITLE
Refactor so imports aren't used unless needed

### DIFF
--- a/abstract_ranker/driver.py
+++ b/abstract_ranker/driver.py
@@ -1,0 +1,46 @@
+from typing import Generator, Tuple
+
+from abstract_ranker.data_model import AbstractLLMResponse, Contribution
+from abstract_ranker.llm_utils import query_llm
+
+from abstract_ranker.config import interested_topics, not_interested_topics
+
+
+def process_contributions(
+    contributions: Generator[Contribution, None, None],
+    prompt: str,
+    model: str,
+    use_cache: bool,
+) -> Generator[Tuple[Contribution, AbstractLLMResponse], None, None]:
+    """Feed each contribution to the LLM, and get back the summary information.
+
+    Args:
+        contributions (Generator[Contribution, None, None]): The contribution list.
+        prompt (str): The prompt to feed the LLM.
+        model (str): The name of the model to run
+        use_cache (bool): If False, don't use the LLM cache.
+
+    Yields:
+        Generator[Tuple[Contribution, AbstractLLMResponse], None, None]: The summary data
+                                            from the LLM.
+    """
+
+    for contrib in contributions:
+        abstract_text = (
+            contrib.abstract
+            if not (contrib.abstract is None or len(contrib.abstract) < 10)
+            else "Not given"
+        )
+        summary = query_llm(
+            prompt,
+            {
+                "title": contrib.title,
+                "abstract": abstract_text,
+                "interested_topics": interested_topics,
+                "not_interested_topics": not_interested_topics,
+            },
+            model,
+            use_cache,
+        )
+
+        yield contrib, summary

--- a/abstract_ranker/output.py
+++ b/abstract_ranker/output.py
@@ -1,0 +1,62 @@
+import csv
+import logging
+from pathlib import Path
+from typing import Generator, Tuple
+
+from abstract_ranker.data_model import AbstractLLMResponse, Contribution
+from abstract_ranker.utils import as_a_number
+
+
+def dump_to_csv_file(
+    output_filename: Path,
+    data: Generator[Tuple[Contribution, AbstractLLMResponse], None, None],
+    progress_bar: bool,
+):
+    # Open the CSV file in write mode
+    with output_filename.open(mode="w", newline="", encoding="utf-8") as file:
+        writer = csv.writer(file)
+
+        # Write the header row
+        writer.writerow(
+            [
+                "Date",
+                "Time",
+                "Room",
+                "Title",
+                "Summary",
+                "Experiment",
+                "Keywords",
+                "Interest",
+                "Type",
+                "Confidence",
+                "Unknown Terms",
+            ]
+        )
+
+        for contrib, summary in data:
+            # Write the row to the CSV file
+            writer.writerow(
+                [
+                    (
+                        contrib.startDate.strftime("%Y-%m-%d %H:%M:%S")
+                        if contrib.startDate
+                        else ""
+                    ),
+                    (
+                        contrib.startDate.strftime("%Y-%m-%d %H:%M:%S")
+                        if contrib.startDate
+                        else ""
+                    ),
+                    contrib.roomFullname if contrib.roomFullname else "",
+                    contrib.title,
+                    summary.summary,
+                    summary.experiment,
+                    summary.keywords,
+                    as_a_number(summary.interest),
+                    contrib.type,
+                    summary.confidence,
+                    summary.unknown_terms,
+                ]
+            )
+    # Print a message indicating the CSV file has been created
+    logging.info(f"CSV file '{output_filename}' has been created.")


### PR DESCRIPTION
* Protect import statements from happening unless they are needed
* Speeds up how fast `help` text is generated, for example.

Fixes #23